### PR TITLE
Field 'aud' is an array and not a string anymore (after migration to …

### DIFF
--- a/server/keycloak/gin-keycloak.go
+++ b/server/keycloak/gin-keycloak.go
@@ -44,7 +44,7 @@ type KeyCloakToken struct {
 	Nbf               int64                  `json:"nbf"`
 	Iat               int64                  `json:"iat"`
 	Iss               string                 `json:"iss"`
-	Aud               string                 `json:"aud"`
+	Aud               []string               `json:"aud"`
 	Sub               string                 `json:"sub"`
 	Typ               string                 `json:"typ"`
 	Azp               string                 `json:"azp"`


### PR DESCRIPTION
…RH-SSO version 7.3).