### PR TITLE
Set a skip tag for easier filtering

### DIFF
--- a/server/tower/shared.go
+++ b/server/tower/shared.go
@@ -62,6 +62,8 @@ func launchJobTemplate(job_template string, json *gabs.Container, username strin
 	json.SetP(username, "extra_vars.custom_tower_user_name")
 	log.Printf("%+v", json)
 
+	json.SetP("ssp_filter_"+username, "skip_tags")
+
 	resp, err := getTowerHTTPClient("POST", "job_templates/"+job_template+"/launch/", bytes.NewReader(json.Bytes()))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This sets a skip tag 'ssp_filter_u11111' on each job, so that filtering is easier when listing the users jobs. I will switch the listing in a different pull request to ensure that the user doesn't "lose" any jobs.