### PR TITLE
Change filter to AND

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ env_vars
 config.yaml
 gopkg*
 vendor/
+
+# MacOS files
+.DS_Store

--- a/server/openshift/project.go
+++ b/server/openshift/project.go
@@ -97,19 +97,13 @@ func getProjectsHandler(c *gin.Context) {
 // filter projects by accountingNumber AND megaID
 // this is used by ESTA
 func filterProjects(projects *gabs.Container, accountingNumber, megaID string) *gabs.Container {
-	if accountingNumber == "" && megaID == "" {
-		return projects
-	}
 	filtered, _ := gabs.New().Array()
 	for _, project := range projects.Children() {
-		m, ok := project.Search("metadata", "annotations", "openshift.io/MEGAID").Data().(string)
-		if !ok {
-			continue
-		}
-		a, ok := project.Search("metadata", "annotations", "openshift.io/kontierung-element").Data().(string)
-		if !ok {
-			continue
-		}
+		// for these searches we ignore "ok" because we consider that when the key "MEGAID" is not
+		// present, this is equivalent to having MegaID = ""
+		m, _ := project.Search("metadata", "annotations", "openshift.io/MEGAID").Data().(string)
+		// same case for accounting number
+		a, _ := project.Search("metadata", "annotations", "openshift.io/kontierung-element").Data().(string)
 		if m == megaID && a == accountingNumber {
 			filtered.ArrayAppend(project.Data())
 		}

--- a/server/openshift/project.go
+++ b/server/openshift/project.go
@@ -100,7 +100,7 @@ func filterProjects(projects *gabs.Container, accountingNumber, megaID string) *
 	if accountingNumber == "" && megaID == "" {
 		return projects
 	}
-	filtered := gabs.New()
+	filtered, _ := gabs.New().Array()
 	for _, project := range projects.Children() {
 		m, ok := project.Search("metadata", "annotations", "openshift.io/MEGAID").Data().(string)
 		if !ok {

--- a/server/openshift/project_test.go
+++ b/server/openshift/project_test.go
@@ -8,30 +8,59 @@ import (
 )
 
 func TestProjectFilter(t *testing.T) {
-	projects, _ := gabs.ParseJSON([]byte(`[
+	projects, err := gabs.ParseJSON([]byte(`[
 		{
 			"metadata": {
 				"annotations": {
-					"openshift.io/MEGAID": "1234",
-					"openshift.io/kontierung-element": "5678"
+					"openshift.io/kontierung-element": "5678",
+					"openshift.io/MEGAID": "1234"
 				}
 			}
 		},
 		{
 			"metadata": {
 				"annotations": {
-					"openshift.io/MEGAID": "5678",
-					"openshift.io/kontierung-element": "1234"
+					"openshift.io/kontierung-element": "5678",
+					"openshift.io/MEGAID": "8080"
+				}
+			}
+		},
+		{
+			"metadata": {
+				"annotations": {
+					"openshift.io/kontierung-element": "8888",
+					"openshift.io/MEGAID": ""
+				}
+			}
+		},
+		{
+			"metadata": {
+				"annotations": {
+					"openshift.io/kontierung-element": "5678",
+					"openshift.io/MEGAID": "1235"
+				}
+			}
+		},
+		{
+			"metadata": {
+				"annotations": {
+					"openshift.io/kontierung-element": "5050",
+					"openshift.io/MEGAID": "5678"
 				}
 			}
 		}
 	]`))
+	if err != nil {
+		t.Error("Invalid JSON!")
+		return
+
+	}
 	var searchsets = []struct {
 		inAccountingNumber string
 		inMegaId           string
 		numberOfResults    int
 	}{
-		{"1234", "5678", 1},
+		{"1234", "5678", 0},
 		{"5678", "1234", 1},
 	}
 

--- a/server/openshift/project_test.go
+++ b/server/openshift/project_test.go
@@ -1,0 +1,32 @@
+package openshift
+
+import (
+	"testing"
+
+	"github.com/Jeffail/gabs/v2"
+)
+
+func TestProjectFilter(t *testing.T) {
+	projects, _ := gabs.ParseJSON([]byte(`[
+		{
+			"metadata": {
+				"annotations": {
+					"openshift.io/MEGAID": "1234",
+					"openshift.io/kontierung-element": "5678"
+				}
+			}
+		},
+		{
+			"metadata": {
+				"annotations": {
+					"openshift.io/MEGAID": "5678",
+					"openshift.io/kontierung-element": "1234"
+				}
+			}
+		}
+	]`))
+	filteredProjects := filterProjects(projects, "1234", "5678")
+	if len(filteredProjects.Children()) != 1 {
+		t.Errorf("ERROR: number of filtered projects should be 1, but is: %v", len(filteredProjects.Children()))
+	}
+}

--- a/server/openshift/project_test.go
+++ b/server/openshift/project_test.go
@@ -36,8 +36,30 @@ func TestProjectFilter(t *testing.T) {
 		{
 			"metadata": {
 				"annotations": {
+					"openshift.io/kontierung-element": "8888"
+				}
+			}
+		},
+		{
+			"metadata": {
+				"annotations": {
 					"openshift.io/kontierung-element": "5678",
 					"openshift.io/MEGAID": "1235"
+				}
+			}
+		},
+		{
+			"metadata": {
+				"annotations": {
+					"openshift.io/kontierung-element": "",
+					"openshift.io/MEGAID": "9999"
+				}
+			}
+		},
+		{
+			"metadata": {
+				"annotations": {
+					"openshift.io/MEGAID": "9999"
 				}
 			}
 		},
@@ -62,6 +84,8 @@ func TestProjectFilter(t *testing.T) {
 	}{
 		{"1234", "5678", 0},
 		{"5678", "1234", 1},
+		{"8888", "", 2},
+		{"", "9999", 2},
 	}
 
 	for _, set := range searchsets {

--- a/server/openshift/project_test.go
+++ b/server/openshift/project_test.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Jeffail/gabs/v2"
@@ -25,8 +26,21 @@ func TestProjectFilter(t *testing.T) {
 			}
 		}
 	]`))
-	filteredProjects := filterProjects(projects, "1234", "5678")
-	if len(filteredProjects.Children()) != 1 {
-		t.Errorf("ERROR: number of filtered projects should be 1, but is: %v", len(filteredProjects.Children()))
+	var searchsets = []struct {
+		inAccountingNumber string
+		inMegaId           string
+		numberOfResults    int
+	}{
+		{"1234", "5678", 1},
+		{"5678", "1234", 1},
+	}
+
+	for _, set := range searchsets {
+		t.Run(fmt.Sprintf("accountingNumber=%s megaId=%s", set.inAccountingNumber, set.inMegaId), func(t *testing.T) {
+			filteredProjects := filterProjects(projects, set.inAccountingNumber, set.inMegaId)
+			if len(filteredProjects.Children()) != set.numberOfResults {
+				t.Errorf("ERROR: number of filtered projects should be %v, but is: %v", set.numberOfResults, len(filteredProjects.Children()))
+			}
+		})
 	}
 }


### PR DESCRIPTION
- now the filter checks that the MegaID AND the Accounting Number match!
  - when Mega ID or Accounting Number in the search is empty, it really matches projects with empty fields
  - when Mega ID or Accounting Number in the metadata of a project is an empty string or not present, it is interpreted as empty string
- corrected the type of the filtered struct, it's a JSON Array and not a JSON Object
- added the very first test in go, that checks the filterProjects behavior