### PR TITLE
fixing the filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The current role maintainer is the SBB Cloud Platform Team.
 
 ### Added
 
+- Fixed the filter on `server/openshift/project.go` for the REST call `api/ose/projects`, so it
+  filters if the parameter is specified, even as an empty string, but does not filter if the
+  parameter is not specified (the behavior in 3.9.0 was that if the parameter was not present, it
+  interpreted it as an empty string)
 
 ## [3.9.0](https://github.com/SchweizerischeBundesbahnen/ssp-backend/compare/v3.9.0...v3.8.1) - 29.07.2020
 

--- a/server/openshift/project.go
+++ b/server/openshift/project.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"fmt"
@@ -77,8 +78,6 @@ func getProjectsHandler(c *gin.Context) {
 	username := common.GetUserName(c)
 	params := c.Request.URL.Query()
 	clusterId := params.Get("clusterid")
-	accountingNumber := params.Get("sbb_accounting_number")
-	megaID := params.Get("sbb_mega_id")
 	if clusterId == "" {
 		c.JSON(http.StatusBadRequest, common.ApiResponse{Message: wrongAPIUsageError})
 		return
@@ -89,23 +88,53 @@ func getProjectsHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, common.ApiResponse{Message: err.Error()})
 		return
 	}
-	// only return projects that have accountingNumber OR megaID
-	// if both are empty (no filtering), then all projects are returned
-	filteredProjects := filterProjects(projects, accountingNumber, megaID)
+	filteredProjects := filterProjects(projects, params)
 	c.JSON(http.StatusOK, getProjectNames(filteredProjects))
 }
 
-// filter projects by accountingNumber AND megaID
+// generic filter for projects
 // this is used by ESTA
-func filterProjects(projects *gabs.Container, accountingNumber, megaID string) *gabs.Container {
+func filterProjects(projects *gabs.Container, filters url.Values) *gabs.Container {
 	filtered, _ := gabs.New().Array()
+	// possible filters:
+	var filterMap = map[string]string{
+		"sbb_accounting_number": "openshift.io/kontierung-element",
+		"sbb_mega_id":           "openshift.io/MEGAID"}
+	// for logging purposes only
+	for filterName, valueComp := range filters {
+		// this parameter is not a filter
+		if filterName == "clusterid" {
+			continue
+		}
+		_, ok := filterMap[filterName]
+		// skip filters that are not defined here
+		if !ok {
+			log.Printf("WARN: invalid filter name: '%v'!", filterName)
+		} else {
+			log.Printf("filtering projects by '%v': '%v'", filterName, valueComp[0])
+		}
+	}
 	for _, project := range projects.Children() {
-		// for these searches we ignore "ok" because we consider that when the key "MEGAID" is not
-		// present, this is equivalent to having MegaID = ""
-		m, _ := project.Search("metadata", "annotations", "openshift.io/MEGAID").Data().(string)
-		// same case for accounting number
-		a, _ := project.Search("metadata", "annotations", "openshift.io/kontierung-element").Data().(string)
-		if m == megaID && a == accountingNumber {
+		matches := true
+		for filterName, valueComp := range filters {
+			propertyAnnotation, ok := filterMap[filterName]
+			// skip filters that are not defined here
+			if !ok {
+				continue
+			}
+			// for this search we ignore the second returning value ("ok") because we
+			// consider that when the annotation is not present in the project
+			// metadata, this is equivalent to having property = ""
+			v, _ := project.Search("metadata", "annotations", propertyAnnotation).Data().(string)
+			// if any of the values in this loop is different, sets matches to false and
+			// breaks (no need to keep comparing)
+			// this is equivalent to a AND (all values need to match for the project to be appended)
+			if v != valueComp[0] {
+				matches = false
+				break
+			}
+		}
+		if matches {
 			filtered.ArrayAppend(project.Data())
 		}
 	}

--- a/server/openshift/project.go
+++ b/server/openshift/project.go
@@ -100,7 +100,8 @@ func filterProjects(projects *gabs.Container, params url.Values) *gabs.Container
 	var filterMap = map[string]string{
 		"sbb_accounting_number": "openshift.io/kontierung-element",
 		"sbb_mega_id":           "openshift.io/MEGAID"}
-	// discarding parameters with invalid filter names
+	// "filters" is a map containing only the parameters with valid
+	// filter names
 	filters := make(map[string]string)
 	for paramName, paramValues := range params {
 		// this parameter is not a filter

--- a/server/openshift/project_test.go
+++ b/server/openshift/project_test.go
@@ -2,6 +2,7 @@ package openshift
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/Jeffail/gabs/v2"
@@ -91,7 +92,11 @@ func TestProjectFilter(t *testing.T) {
 
 	for _, set := range searchsets {
 		t.Run(fmt.Sprintf("accountingNumber=%s megaId=%s", set.inAccountingNumber, set.inMegaId), func(t *testing.T) {
-			filteredProjects := filterProjects(projects, set.inAccountingNumber, set.inMegaId)
+			// filtering by Accounting Number AND Mega ID
+			params := url.Values{}
+			params.Set("sbb_accounting_number", set.inAccountingNumber)
+			params.Set("sbb_mega_id", set.inMegaId)
+			filteredProjects := filterProjects(projects, params)
 			if len(filteredProjects.Children()) != set.numberOfResults {
 				t.Errorf("ERROR: number of filtered projects should be %v, but is: %v", set.numberOfResults, len(filteredProjects.Children()))
 			}


### PR DESCRIPTION
with this fix, filters can be added dynamically; if there no filters in the query, the function brings all results

queries with params like this:
`/api/ose/projects?clusterid=otc_test_04&sbb_mega_id=`
`/api/ose/projects?clusterid=otc_test_04&sbb_mega_id`

result in filter `sbb_mega_id == ""` (empty string)

so, the function filters by Mega ID == ""

queries with params like this:
`/api/ose/projects?clusterid=otc_test_04`

result in filter `sbb_mega_id == nil`

which gets ignored, so, the function _does not filter_ by Mega ID

so far only accounting number and mega ID are declared as filters but in the future more criteria can be added